### PR TITLE
Improve web UI integration with API

### DIFF
--- a/web/static/app.js
+++ b/web/static/app.js
@@ -4,8 +4,58 @@ const queryInput = document.getElementById('query');
 const sendButton = document.getElementById('send');
 const historyDiv = document.getElementById('history');
 const resultsDiv = document.getElementById('results');
+const statusIndicator = document.getElementById('statusIndicator');
+const checkConnectionButton = document.getElementById('checkConnection');
 
-const history = [];
+const STORAGE_KEYS = {
+  url: 'rag-video-search-api-url',
+  key: 'rag-video-search-api-key',
+};
+
+const MAX_HISTORY_MESSAGES = 5;
+const conversationHistory = [];
+const activeObjectUrls = new Set();
+
+function ensureApiBase(value) {
+  const trimmed = value.trim();
+  if (!trimmed) return '';
+  const normalized = trimmed.replace(/\/+$/, '');
+  if (normalized.toLowerCase().endsWith('/v1')) {
+    return normalized;
+  }
+  return `${normalized}/v1`;
+}
+
+function loadSettings() {
+  const savedUrl = localStorage.getItem(STORAGE_KEYS.url);
+  const defaultUrl = ensureApiBase(window.location.origin);
+  apiUrlInput.value = savedUrl || defaultUrl;
+  const savedKey = localStorage.getItem(STORAGE_KEYS.key);
+  if (savedKey) {
+    apiKeyInput.value = savedKey;
+  }
+  updateStatus('idle', 'Configure the API endpoint and test the connection.');
+}
+
+function persistSettings() {
+  const apiBase = ensureApiBase(apiUrlInput.value);
+  apiUrlInput.value = apiBase;
+  localStorage.setItem(STORAGE_KEYS.url, apiBase);
+  localStorage.setItem(STORAGE_KEYS.key, apiKeyInput.value.trim());
+}
+
+function getApiBase() {
+  return ensureApiBase(apiUrlInput.value);
+}
+
+function getApiKey() {
+  return apiKeyInput.value.trim();
+}
+
+function clearObjectUrls() {
+  activeObjectUrls.forEach((url) => URL.revokeObjectURL(url));
+  activeObjectUrls.clear();
+}
 
 function addMessage(role, content) {
   const message = document.createElement('div');
@@ -15,21 +65,170 @@ function addMessage(role, content) {
   historyDiv.scrollTop = historyDiv.scrollHeight;
 }
 
+function trimHistory() {
+  const maxEntries = MAX_HISTORY_MESSAGES * 2;
+  if (conversationHistory.length > maxEntries) {
+    conversationHistory.splice(0, conversationHistory.length - maxEntries);
+  }
+}
+
+function updateStatus(state, message) {
+  statusIndicator.textContent = message;
+  statusIndicator.classList.remove('status-ok', 'status-loading');
+  if (state === 'ok') {
+    statusIndicator.classList.add('status-ok');
+  } else if (state === 'loading') {
+    statusIndicator.classList.add('status-loading');
+  }
+}
+
+async function checkConnection() {
+  const baseUrl = getApiBase();
+  if (!baseUrl) {
+    updateStatus('error', 'Enter a valid API endpoint URL.');
+    return;
+  }
+  updateStatus('loading', 'Checking connection…');
+  checkConnectionButton.disabled = true;
+  try {
+    const response = await fetch(`${baseUrl}/health`, {
+      headers: {
+        'x-api-key': getApiKey() || '',
+      },
+    });
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(text || response.statusText);
+    }
+    const data = await response.json();
+    const environment = data.environment ? ` (${data.environment})` : '';
+    updateStatus('ok', `Connected${environment}`);
+  } catch (error) {
+    console.error('Health check failed', error);
+    updateStatus('error', `Connection failed: ${error.message}`);
+  } finally {
+    checkConnectionButton.disabled = false;
+  }
+}
+
+async function loadPreview(manifestId, videoElement, button) {
+  const baseUrl = getApiBase();
+  const apiKey = getApiKey();
+  if (!baseUrl) {
+    addMessage('System', 'Set an API endpoint before loading previews.');
+    return;
+  }
+  if (!apiKey) {
+    addMessage('System', 'Provide an API key to request previews.');
+    return;
+  }
+  button.disabled = true;
+  const previousLabel = button.textContent;
+  button.textContent = 'Loading…';
+  try {
+    const response = await fetch(`${baseUrl}/decode`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': apiKey,
+      },
+      body: JSON.stringify({ manifest_id: manifestId, quality: 'preview' }),
+    });
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(text || response.statusText);
+    }
+    const blob = await response.blob();
+    const objectUrl = URL.createObjectURL(blob);
+    const previousUrl = videoElement.dataset.objectUrl;
+    if (previousUrl) {
+      URL.revokeObjectURL(previousUrl);
+      activeObjectUrls.delete(previousUrl);
+    }
+    videoElement.dataset.objectUrl = objectUrl;
+    activeObjectUrls.add(objectUrl);
+    videoElement.src = objectUrl;
+    videoElement.load();
+    button.textContent = 'Reload preview';
+  } catch (error) {
+    console.error('Preview failed', error);
+    addMessage('System', `Preview error: ${error.message}`);
+    button.textContent = previousLabel;
+  } finally {
+    button.disabled = false;
+  }
+}
+
+function renderResults(results) {
+  clearObjectUrls();
+  resultsDiv.innerHTML = '';
+  if (!results.length) {
+    const empty = document.createElement('p');
+    empty.textContent = 'No results returned for this query.';
+    resultsDiv.appendChild(empty);
+    return;
+  }
+  results.forEach((item) => {
+    const container = document.createElement('div');
+    container.classList.add('result-item');
+
+    const heading = document.createElement('h3');
+    heading.textContent = `${item.label} — score ${item.score.toFixed(3)}`;
+    container.appendChild(heading);
+
+    const meta = document.createElement('div');
+    meta.classList.add('meta');
+    const truncatedId =
+      item.manifest_id.length > 12 ? `${item.manifest_id.slice(0, 8)}…` : item.manifest_id;
+    meta.innerHTML = `
+      <span>Segment: ${item.start_time.toFixed(2)}s → ${item.end_time.toFixed(2)}s</span>
+      <span title="${item.manifest_id}">Manifest ID: ${truncatedId}</span>
+    `;
+    container.appendChild(meta);
+
+    const previewButton = document.createElement('button');
+    previewButton.type = 'button';
+    previewButton.textContent = 'Load preview';
+
+    const video = document.createElement('video');
+    video.controls = true;
+    video.preload = 'none';
+
+    previewButton.addEventListener('click', () => loadPreview(item.manifest_id, video, previewButton));
+
+    container.appendChild(previewButton);
+    container.appendChild(video);
+    resultsDiv.appendChild(container);
+  });
+}
+
 async function search(query) {
-  const apiUrl = apiUrlInput.value.replace(/\/$/, '') + '/search';
-  const apiKey = apiKeyInput.value;
+  const baseUrl = getApiBase();
+  const apiKey = getApiKey();
+  if (!baseUrl) {
+    addMessage('System', 'Set an API endpoint before searching.');
+    return;
+  }
+  if (!apiKey) {
+    addMessage('System', 'Provide an API key to perform searches.');
+    return;
+  }
 
   const payload = {
     query,
-    history,
+    history: conversationHistory.slice(-MAX_HISTORY_MESSAGES * 2),
     options: {
       expand: true,
       top_k: 5,
     },
   };
 
+  sendButton.disabled = true;
+  queryInput.disabled = true;
+  addMessage('System', 'Searching…');
+
   try {
-    const response = await fetch(apiUrl, {
+    const response = await fetch(`${baseUrl}/search/similar`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -45,23 +244,16 @@ async function search(query) {
 
     const data = await response.json();
     addMessage('Assistant', data.answer);
-    resultsDiv.innerHTML = '';
-    data.results.forEach((item) => {
-      const div = document.createElement('div');
-      div.classList.add('result-item');
-      div.innerHTML = `
-        <h3>${item.label} — score ${item.score.toFixed(3)}</h3>
-        <p>Segment: ${item.start_time.toFixed(2)}s → ${item.end_time.toFixed(2)}s</p>
-        <video src="${item.asset_url}" controls></video>
-      `;
-      resultsDiv.appendChild(div);
-    });
-
-    history.push({ role: 'user', content: query });
-    history.push({ role: 'assistant', content: data.answer });
+    renderResults(data.results || []);
+    conversationHistory.push({ role: 'user', content: query });
+    conversationHistory.push({ role: 'assistant', content: data.answer });
+    trimHistory();
   } catch (error) {
     console.error('Search failed', error);
     addMessage('System', `Error: ${error.message}`);
+  } finally {
+    sendButton.disabled = false;
+    queryInput.disabled = false;
   }
 }
 
@@ -75,6 +267,23 @@ sendButton.addEventListener('click', () => {
 
 queryInput.addEventListener('keypress', (event) => {
   if (event.key === 'Enter') {
+    event.preventDefault();
     sendButton.click();
   }
 });
+
+checkConnectionButton.addEventListener('click', checkConnection);
+apiUrlInput.addEventListener('change', () => {
+  persistSettings();
+  updateStatus('idle', 'Settings updated — test the connection.');
+});
+apiKeyInput.addEventListener('change', persistSettings);
+
+window.addEventListener('beforeunload', clearObjectUrls);
+
+loadSettings();
+
+// Automatically test the connection if the user already configured the API URL.
+if (apiUrlInput.value) {
+  checkConnection();
+}

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -16,12 +16,21 @@
         <section class="controls">
           <label>
             API Endpoint
-            <input type="text" id="apiUrl" value="http://localhost:8080" />
+            <input
+              type="text"
+              id="apiUrl"
+              placeholder="http://localhost:8080"
+              autocomplete="off"
+            />
           </label>
           <label>
             API Key
             <input type="password" id="apiKey" placeholder="Enter API key" />
           </label>
+          <div class="status" id="status">
+            <span class="status-indicator" id="statusIndicator"></span>
+            <button id="checkConnection" type="button">Test connection</button>
+          </div>
         </section>
         <section class="chat">
           <div id="history" class="history"></div>

--- a/web/static/styles.css
+++ b/web/static/styles.css
@@ -51,6 +51,66 @@ header h1 {
   color: #94a3b8;
 }
 
+.status {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: rgba(15, 23, 42, 0.65);
+  color: #94a3b8;
+}
+
+.status button {
+  padding: 8px 16px;
+  border-radius: 12px;
+  border: none;
+  background: linear-gradient(135deg, #22d3ee, #6366f1);
+  color: #0f172a;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.status button:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 20px rgba(99, 102, 241, 0.4);
+}
+
+.status button:disabled {
+  opacity: 0.6;
+  cursor: wait;
+}
+
+.status-indicator {
+  position: relative;
+  padding-left: 20px;
+}
+
+.status-indicator::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: #f87171;
+  box-shadow: 0 0 8px rgba(248, 113, 113, 0.6);
+}
+
+.status-indicator.status-ok::before {
+  background: #34d399;
+  box-shadow: 0 0 8px rgba(52, 211, 153, 0.6);
+}
+
+.status-indicator.status-loading::before {
+  background: #fbbf24;
+  box-shadow: 0 0 8px rgba(251, 191, 36, 0.6);
+}
+
 .controls input {
   padding: 10px 12px;
   border-radius: 12px;
@@ -127,6 +187,40 @@ header h1 {
 
 .result-item h3 {
   margin: 0 0 8px 0;
+}
+
+.result-item .meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  font-size: 0.9rem;
+  color: #94a3b8;
+}
+
+.result-item .meta span {
+  white-space: nowrap;
+}
+
+.result-item button {
+  margin-top: 12px;
+  padding: 10px 18px;
+  border-radius: 12px;
+  border: none;
+  background: linear-gradient(135deg, #38bdf8, #818cf8);
+  color: #0f172a;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.result-item button:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 20px rgba(129, 140, 248, 0.4);
+}
+
+.result-item button:disabled {
+  opacity: 0.6;
+  cursor: wait;
 }
 
 .result-item video {


### PR DESCRIPTION
## Summary
- update the static UI to default to the FastAPI /v1 endpoints, add a connection tester, and support preview streaming via the decode route
- refresh styling for the new status indicator and result preview controls for easier manual verification

## Testing
- pytest *(fails: tests/test_rate_limit.py::test_rate_limiter_memory requires an async pytest plugin such as pytest-asyncio)*

------
https://chatgpt.com/codex/tasks/task_e_68e1d14b8b4c832db001d317ab2d325c